### PR TITLE
refactor: use theme tokens for invoice styles

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -146,7 +146,7 @@
 
   /* Mobile progress indicators */
   .progress-mobile {
-    @apply w-full h-1 bg-gray-200 rounded-full overflow-hidden;
+    @apply w-full h-1 bg-muted rounded-full overflow-hidden;
   }
 
   .progress-fill {
@@ -186,7 +186,7 @@
 
   /* Mobile upload areas */
   .upload-area-mobile {
-    @apply border-2 border-dashed border-gray-300 rounded-xl p-6 text-center hover:border-gray-400 transition-colors cursor-pointer;
+    @apply border-2 border-dashed border-border rounded-xl p-6 text-center hover:border-muted-foreground transition-colors cursor-pointer;
   }
 
   /* Mobile animations */
@@ -231,7 +231,7 @@
 
 /* Invoice specific styles */
 .invoice-preview {
-  @apply bg-white shadow-lg rounded-lg p-4 sm:p-8 max-w-4xl mx-auto;
+  @apply bg-card text-card-foreground shadow-lg rounded-lg p-4 sm:p-8 max-w-4xl mx-auto;
 }
 
 .invoice-table {
@@ -239,15 +239,15 @@
 }
 
 .invoice-table th {
-  @apply bg-gray-50 text-left p-3 border-b border-gray-200 font-medium text-gray-700;
+  @apply bg-muted text-left p-3 border-b border-border font-medium text-foreground;
 }
 
 .invoice-table td {
-  @apply p-3 border-b border-gray-100;
+  @apply p-3 border-b border-border;
 }
 
 .invoice-total {
-  @apply bg-gray-50 font-semibold;
+  @apply bg-muted text-foreground font-semibold;
 }
 
 /* Watermark for free users */


### PR DESCRIPTION
## Summary
- replace hardcoded gray and white classes with theme tokens
- base invoice table styles on CSS variables for dark mode

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires ESLint configuration)

------
https://chatgpt.com/codex/tasks/task_e_6895ec42f1508328a3da8e61cbb716c8