### PR TITLE
refactor: use theme tokens for mobile progress and upload area

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -146,11 +146,11 @@
 
   /* Mobile progress indicators */
   .progress-mobile {
-    @apply w-full h-1 bg-gray-200 rounded-full overflow-hidden;
+    @apply w-full h-1 bg-muted rounded-full overflow-hidden;
   }
 
   .progress-fill {
-    @apply h-full bg-blue-600 transition-all duration-500 ease-out;
+    @apply h-full bg-primary transition-all duration-500 ease-out;
   }
 
   /* Mobile grid layouts */
@@ -186,7 +186,7 @@
 
   /* Mobile upload areas */
   .upload-area-mobile {
-    @apply border-2 border-dashed border-gray-300 rounded-xl p-6 text-center hover:border-gray-400 transition-colors cursor-pointer;
+    @apply border-2 border-dashed border-border rounded-xl p-6 text-center hover:border-border/80 transition-colors cursor-pointer;
   }
 
   /* Mobile animations */


### PR DESCRIPTION
## Summary
- use `bg-muted` for `.progress-mobile` background
- make `.progress-fill` use `bg-primary`
- swap upload area borders to theme tokens

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (interactive prompt to configure ESLint)


------
https://chatgpt.com/codex/tasks/task_e_6895ec45363c83288234dc39c8925aea