### PR TITLE
Use theme background for billing knob

### DIFF
--- a/src/app/upgrade/page.tsx
+++ b/src/app/upgrade/page.tsx
@@ -125,7 +125,7 @@ export default function UpgradePage() {
               }`}
             >
               <span
-                className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                className={`inline-block h-4 w-4 transform rounded-full bg-background border border-border transition-transform ${
                   billingCycle === 'yearly' ? 'translate-x-6' : 'translate-x-1'
                 }`}
               />


### PR DESCRIPTION
## Summary
- ensure billing cycle toggle knob uses theme background and border for light/dark compatibility

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_6895ec47dd5883289abfbb35646be160