### PR TITLE
feat: add pre-hydration theme script

### DIFF
--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { createContext, useContext, useEffect, useState } from 'react';
+import Script from 'next/script';
 
 type Theme = 'light' | 'dark';
 type AccentColor = 'orange' | 'blue' | 'purple' | 'green';
@@ -20,24 +21,31 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [accentColor, setAccentColor] = useState<AccentColor>('orange');
   const [mounted, setMounted] = useState(false);
 
-  // Load theme from localStorage on mount
+  // Load theme from localStorage on mount and listen for system preference changes
   useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
     const savedTheme = localStorage.getItem('timeflow-theme') as Theme;
     const savedAccent = localStorage.getItem('timeflow-accent') as AccentColor;
-    
+
     if (savedTheme) {
       setTheme(savedTheme);
     } else {
       // Auto-detect system preference
-      const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      setTheme(systemDark ? 'dark' : 'light');
+      setTheme(mediaQuery.matches ? 'dark' : 'light');
     }
-    
+
     if (savedAccent) {
       setAccentColor(savedAccent);
     }
-    
+
     setMounted(true);
+
+    const handleChange = (e: MediaQueryListEvent) => {
+      setTheme(e.matches ? 'dark' : 'light');
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
   }, []);
 
   // Apply theme and accent to document
@@ -71,23 +79,40 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     setAccentColor(color);
   };
 
-  // Prevent hydration mismatch
-  if (!mounted) {
-    return <>{children}</>;
-  }
-
   return (
-    <ThemeContext.Provider
-      value={{
-        theme,
-        accentColor,
-        setTheme: handleSetTheme,
-        setAccentColor: handleSetAccentColor,
-        toggleTheme,
-      }}
-    >
-      {children}
-    </ThemeContext.Provider>
+    <>
+      <Script id="initial-theme" strategy="beforeInteractive">
+        {`
+          (function() {
+            try {
+              var theme = localStorage.getItem('timeflow-theme');
+              if (!theme) {
+                var systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+                theme = systemDark ? 'dark' : 'light';
+              }
+              var root = document.documentElement;
+              root.classList.remove('light', 'dark');
+              root.classList.add(theme);
+            } catch (e) {}
+          })();
+        `}
+      </Script>
+      {mounted ? (
+        <ThemeContext.Provider
+          value={{
+            theme,
+            accentColor,
+            setTheme: handleSetTheme,
+            setAccentColor: handleSetAccentColor,
+            toggleTheme,
+          }}
+        >
+          {children}
+        </ThemeContext.Provider>
+      ) : (
+        <>{children}</>
+      )}
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- set theme before hydration from localStorage via inline script
- react to system color scheme changes with matchMedia listener

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: If you set up ESLint yourself, we recommend adding the Next.js ESLint plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6895ec48d2688328ac12c7bd320e9a86