### PR TITLE
feat: add mobile header theme toggle

### DIFF
--- a/src/components/MobileNavigation.tsx
+++ b/src/components/MobileNavigation.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { Upload, Settings, FileText, Menu, X } from 'lucide-react';
+import { SimpleThemeToggle } from './ThemeToggle';
 
 interface MobileNavigationProps {
   currentStep: 'upload' | 'configure' | 'preview';
@@ -47,6 +48,7 @@ export default function MobileNavigation({ currentStep, onStepChange }: MobileNa
           </div>
           
           <div className="flex items-center space-x-2">
+            <SimpleThemeToggle />
             <span className="text-xs text-muted-foreground bg-muted px-2 py-1 rounded-full">
               Free
             </span>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -149,14 +149,14 @@ function SimpleThemeToggleContent() {
   return (
     <button
       onClick={toggleTheme}
-      className="p-2 rounded-lg bg-card border border-border hover:bg-secondary/50 transition-all duration-200"
+      className="p-2 rounded-lg bg-card border border-border hover:bg-secondary/50 transition-all duration-200 touch-target"
       title={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
     >
       <div className="relative w-4 h-4">
-        <Sun 
+        <Sun
           className={`absolute inset-0 w-4 h-4 text-foreground transition-all duration-300 ${
             theme === 'light' ? 'rotate-0 scale-100' : 'rotate-90 scale-0'
-          }`} 
+          }`}
         />
         <Moon 
           className={`absolute inset-0 w-4 h-4 text-foreground transition-all duration-300 ${


### PR DESCRIPTION
## Summary
- add theme toggle to mobile header actions
- ensure theme toggle button meets touch target size

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_6895ec49ce3c8328b64525490cc6d262